### PR TITLE
Add MAX_BULK_BUFFER_LENGTH constant to prevent ENOMEM on Android

### DIFF
--- a/isochronous_linux.go
+++ b/isochronous_linux.go
@@ -25,6 +25,11 @@ const (
 	USBDEVFS_URB_NO_INTERRUPT      = 0x80
 )
 
+// MAX_BULK_BUFFER_LENGTH matches libusb's limit and the Linux kernel's
+// MAX_USBFS_BUFFER_SIZE (drivers/usb/core/devio.c). Exceeding this can
+// cause ENOMEM on URB submission, especially on Android/ARM platforms.
+const MAX_BULK_BUFFER_LENGTH = 16384
+
 // IsoPacketDescriptor represents a single isochronous packet
 type IsoPacketDescriptor struct {
 	Length       uint32


### PR DESCRIPTION
## Summary
- Add `MAX_BULK_BUFFER_LENGTH` constant (16KB) matching libusb's limit and the Linux kernel's `MAX_USBFS_BUFFER_SIZE`

Large bulk transfer buffers can cause ENOMEM on Android/ARM platforms due to kernel usbfs memory limits. This constant helps callers avoid this issue by providing a known-safe maximum buffer size for bulk transfers.

## Test plan
- [x] Verify constant value matches libusb's MAX_BULK_BUFFER_LENGTH (16384 bytes)
- [ ] Test bulk transfers on Android with buffers at or below this limit

:robot: Generated with [Claude Code](https://claude.com/claude-code)