### PR TITLE
fix: cap bulk transfer buffer size to 16KB to match libusb

### DIFF
--- a/isochronous_linux.go
+++ b/isochronous_linux.go
@@ -25,6 +25,9 @@ const (
 	USBDEVFS_URB_NO_INTERRUPT      = 0x80
 )
 
+// MAX_BULK_BUFFER_LENGTH matches libusb's limit to avoid kernel memory issues on Android
+const MAX_BULK_BUFFER_LENGTH = 16384
+
 // IsoPacketDescriptor represents a single isochronous packet
 type IsoPacketDescriptor struct {
 	Length       uint32
@@ -346,6 +349,11 @@ func (h *DeviceHandle) NewAsyncBulkTransfer(endpoint uint8, bufferSize int) (*As
 
 	if h.closed {
 		return nil, ErrDeviceNotFound
+	}
+
+	// Cap buffer size to avoid ENOMEM on Android/limited systems
+	if bufferSize > MAX_BULK_BUFFER_LENGTH {
+		bufferSize = MAX_BULK_BUFFER_LENGTH
 	}
 
 	// Allocate buffer


### PR DESCRIPTION
On Android and other systems with limited usbfs memory, submitting URBs with large buffers (e.g., 2MB based on dwMaxPayloadTransferSize) causes ENOMEM errors after just a few URBs.

libusb caps bulk transfer buffers at MAX_BULK_BUFFER_LENGTH (16384 bytes) regardless of the requested size. This allows it to submit many more URBs without hitting kernel memory limits.

This change applies the same 16KB cap to NewAsyncBulkTransfer, fixing streaming failures on Android devices with UVC cameras that report large max payload sizes.